### PR TITLE
Updated changeImage method to call showImage

### DIFF
--- a/src/js/ngGallery.js
+++ b/src/js/ngGallery.js
@@ -107,10 +107,7 @@ angular.module('jkuri.gallery', [])
 
 			scope.changeImage = function (i) {
 				scope.index = i;
-				loadImage(scope.index).then(function(resp) {
-					scope.img = resp.src;
-					smartScroll(scope.index);
-				});
+                		showImage(scope.index);
 			};
 
 			scope.nextImage = function () {


### PR DESCRIPTION
The description of an image was not being updated when clicking a thumbnail (which calls the changeImage method.) So, updated changeImage to call showImage like the nextImage and prevImage functions do, which loads the image if necessary and sets the description.
