### PR TITLE
Fix controller to work in strict dependency injection mode

### DIFF
--- a/src/js/ngGallery.js
+++ b/src/js/ngGallery.js
@@ -60,11 +60,14 @@
 				images: '=',
 				thumbsNum: '@'
 			},
-			controller: function($scope) {
-				$scope.$on('openGallery', function(e, args) {
-					$scope.openGallery(args.index);
-				});
-			},
+			controller: [
+				'$scope',
+				function($scope) {
+					$scope.$on('openGallery', function(e, args) {
+						$scope.openGallery(args.index);
+					});
+				}
+			],
 			templateUrl: function (element, attrs) {
 				return attrs.templateUrl || defaults.templateUrl;
 			},


### PR DESCRIPTION
Previous commit introduced a controller on the gallery, but its definition was using implicit dependency injection, breaking the module when minifying.
